### PR TITLE
Fix bug with binding to a port that is already taken

### DIFF
--- a/Source/HttpServerExample/Private/HttpServer.cpp
+++ b/Source/HttpServerExample/Private/HttpServer.cpp
@@ -38,12 +38,9 @@ void AHttpServer::StartServer()
 	}
 
 	FHttpServerModule& httpServerModule = FHttpServerModule::Get();
-	TSharedPtr<IHttpRouter> httpRouter = httpServerModule.GetHttpRouter(ServerPort);
+	TSharedPtr<IHttpRouter> httpRouter = httpServerModule.GetHttpRouter(ServerPort, true);
 
 	// If port already binded by another process, then this check must be failed
-	// !!! BUT !!!
-	// this check always true
-	// I don't no why...
 	if (httpRouter.IsValid())
 	{
 		// You can bind as many routes as you need


### PR DESCRIPTION
Thanks for making this demo!

I fixed the bug you mentioned in your comment. :)

You need to supply the optional parameter to fail on binding error which defaults to false.